### PR TITLE
Add test data and endpoint

### DIFF
--- a/app/Http/Controllers/Api/ApiTestController.php
+++ b/app/Http/Controllers/Api/ApiTestController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\TestModel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ApiTestController extends ApiController
+{
+    /**
+     * Return a test record based on the provided number parameter.
+     */
+    public function fetch(Request $request): JsonResponse
+    {
+        $number = $request->input('number');
+
+        if ($number === null) {
+            return response()->json(['error' => 'number parameter is required'], 422);
+        }
+
+        $record = TestModel::find((int) $number);
+
+        if ($record === null) {
+            return response()->json(['test' => null], 200);
+        }
+
+        return response()->json(['test' => $record], 200);
+    }
+}

--- a/app/Models/TestModel.php
+++ b/app/Models/TestModel.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $task
+ * @property int $age
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+class TestModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'tests';
+
+    protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'name' => 'string',
+        'task' => 'string',
+        'age' => 'integer',
+    ];
+}

--- a/database/migrations/2503142032_create_tests_table.php
+++ b/database/migrations/2503142032_create_tests_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tests', function (Blueprint $table) {
+            $table->id()->index();
+            $table->string('name');
+            $table->string('task');
+            $table->integer('age');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tests');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Database\Seeders\Initialization\InitializationMoviesSeeder;
 use Database\Seeders\Initialization\InitializationProjectionsSeeder;
+use Database\Seeders\Initialization\InitializationTestsSeeder;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -16,6 +17,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             InitializationMoviesSeeder::class,
             InitializationProjectionsSeeder::class,
+            InitializationTestsSeeder::class,
         ]);
     }
 }

--- a/database/seeders/Initialization/InitializationTestsSeeder.php
+++ b/database/seeders/Initialization/InitializationTestsSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders\Initialization;
+
+use Database\Seeders\Initialization\Tests\TestsSeeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class InitializationTestsSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    /**
+     * Run the database seeders.
+     */
+    public function run(): void
+    {
+        $this->call([
+            TestsSeeder::class,
+        ]);
+    }
+}

--- a/database/seeders/Initialization/Tests/TestsSeeder.php
+++ b/database/seeders/Initialization/Tests/TestsSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders\Initialization\Tests;
+
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TestsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('tests')->insert([
+            ['name' => 'Alice', 'task' => 'Task 1', 'age' => 20, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+            ['name' => 'Bob',   'task' => 'Task 2', 'age' => 25, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+            ['name' => 'Carol', 'task' => 'Task 3', 'age' => 30, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+            ['name' => 'Dave',  'task' => 'Task 4', 'age' => 35, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+            ['name' => 'Eve',   'task' => 'Task 5', 'age' => 40, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\ApiMovieController;
 use App\Http\Controllers\Api\ApiProjectionController;
+use App\Http\Controllers\Api\ApiTestController;
 use Illuminate\Support\Facades\Route;
 
 Route::name('api.')
@@ -22,4 +23,9 @@ Route::name('api.')
         Route::post('/projection/create', [ApiProjectionController::class, 'create']);
         Route::post('/projection/update/{id}/field/{field}', [ApiProjectionController::class, 'update']);
         Route::delete('/projection/delete/{id}', [ApiProjectionController::class, 'delete']);
+
+        /**
+         * Tests
+         */
+        Route::get('/tests', [ApiTestController::class, 'fetch']);
 });


### PR DESCRIPTION
## Summary
- add migration and seeders for a `tests` table
- create `TestModel` model
- implement `ApiTestController` with `/api/tests` endpoint
- register the new route

## Testing
- `php` was not available so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_68407184e59c8330a65390b319631163